### PR TITLE
Amend project data to include package metadata and include build instructions in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,25 @@ languages such as [F#](http://research.microsoft.com/en-us/projects/fsharp/),
 and [Nemerle](http://nemerle.org/About/) for the purpose of demonstrating
 capability. At this moment, XSharpX uses C# exclusively for implementation.
 
+## Installation
+
+TODO: This section will be true after the package is built and uploaded to nuget.org, pending review of the package metadata
+
+Nuget packages of stable builds are available on nuget.org, with package id XSharpX. The latest version is pre-release version 1.0.0-RC
+
+Install using NuGet with
+
+```
+nuget install XSharpX -prerelease
+```
+
+in Visual Studio from the package-management console with
+
+```
+install-package XSharpX -IncludePrerelease
+```
+
+or in Visual Studio from the NuGet Package Manager GUI
 
 ## Quick Start
 
@@ -16,6 +35,25 @@ capability. At this moment, XSharpX uses C# exclusively for implementation.
 using XSharpX;
 // ...
 ```
+
+## Building
+
+Build using the dotnet core. The project uses tools version 15, for which you need core tools SDK 1.1 or higher, which can be installed from https://www.microsoft.com/net/core
+
+Build the project from the root directory of the project with
+
+```
+dotnet build src/XSharpx/XSharpx.csproj
+```
+
+To build a nuget package in release configuration, build with
+
+```
+dotnet pack src/XSharpx/XSharpx.csproj -c:Release
+```
+
+build artifacts will be created in src/XSharpx/bin
+
 
 ## Support and Community
 

--- a/bin/dll
+++ b/bin/dll
@@ -1,5 +1,0 @@
-#!/bin/sh
-
-mkdir -p dist
-gmcs -target:library -out:dist/XSharpx.dll src/XSharpx/*.cs
-

--- a/src/XSharpx/XSharpx.csproj
+++ b/src/XSharpx/XSharpx.csproj
@@ -4,6 +4,15 @@
     <AssemblyName>XSharpx</AssemblyName>
     <RootNamespace>XSharpx</RootNamespace>
   </PropertyGroup>
+  <PropertyGroup Label="Packaging">
+    <PackageVersion>1.0.0-RC</PackageVersion>
+    <PackageID>XSharpX</PackageID>
+    <Description>A general library for functional programming using .NET languages. It provides purely functional data structures to complement those from the BCEL.</Description>
+    <Authors>Tony Morris, XSharpX contributors</Authors>
+    <PackageLicenseUrl>https://github.com/data61/xsharpx/blob/master/LICENCE</PackageLicenseUrl>
+    <PackageProjectUrl>https://github.com/data61/xsharpx</PackageProjectUrl>
+    <PackageTags>Functional Datastructures</PackageTags>
+  </PropertyGroup>
   <PropertyGroup>
     <TargetFramework>netstandard1.3</TargetFramework>
   </PropertyGroup>
@@ -18,6 +27,6 @@
     <PackageReference Include="NETStandard.Library">
       <Version>1.3</Version>
     </PackageReference>
- </ItemGroup>
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>


### PR DESCRIPTION
I'm working on CI through appveyor, but I'm hitting some problems (and the "fiddle with a yaml file, push the branch, see what the CI does with it, determine what the problem is, fiddle with it some more" workflow is really bothersome and slow).

Because I'm taking so long with CI integration, I want to propose to publish a package manually.

This PR includes building instructions in the READEME.md which you can use to publish a package. With this toolchain, I think the need (and applicability) of the bin/dll build script is gone, so I've removed that in this PR as well. I've only tested buiding on Windows machines, so checking whether the instructions hold on other platforms is likely worthwhile.

The metadata for the package comes from the csproj file, particularly the properties in `<PropertyGroup Label="Packaging">`

Packages are uniquely defined by their package ID in the PackageID element. Changing the package ID means it's seen as a different package. Changing the case of the package ID means the package is more or less hopelessly broken (see: http://adamralph.com/2015/03/04/nuget-gallery-casing-woes/). The "latest version" is determined by the version number according to SemVer.

That means that you're free to change any meta-data when publishing a new version after release without any permanent technical consequences, with the exception of Package ID (which should never change) and Version (which should always change to be higher than the previous version according to SemVer), so take particular care reviewing those porperties

Documentation on manual publishing to nuget.org can be found on https://docs.nuget.org/ndocs/create-packages/publish-a-package